### PR TITLE
Fix for atcute/bluesky example code

### DIFF
--- a/packages/definitions/bluesky/README.md
+++ b/packages/definitions/bluesky/README.md
@@ -57,7 +57,7 @@ const record: AppBskyFeedPost.Record = {
 ```
 
 ```ts
-const rpc = new XRPC({ handle: simpleFetchHandler({ service: 'https://api.bsky.app' }) });
+const rpc = new XRPC({ handler: simpleFetchHandler({ service: 'https://api.bsky.app' }) });
 
 const { data } = await rpc.get('app.bsky.actor.getProfile', {
 	params: {


### PR DESCRIPTION
While the property on the XRPC class is called `handle`, the constructor takes in `handler`. This fixes the docs to reflect that, but alternatively you could change the class constructor to use `handle` everywhere.