### PR TITLE
chore(lex-cli): use .optional(() => x) in schemas

### DIFF
--- a/packages/core/lex-cli/src/schema.ts
+++ b/packages/core/lex-cli/src/schema.ts
@@ -119,7 +119,7 @@ export const refUnionSchema = v
 		type: v.literal('union'),
 		description: v.string().optional(),
 		refs: v.array(v.string()),
-		closed: v.boolean().default(false),
+		closed: v.boolean().optional(() => false),
 	})
 	.assert((v) => !v.closed || v.refs.length > 0, `A closed union can't have empty refs list`);
 
@@ -177,8 +177,8 @@ export const objectSchema = v
 	.object({
 		type: v.literal('object'),
 		description: v.string().optional(),
-		required: v.array(v.string()).default<string[]>([]),
-		nullable: v.array(v.string()).default<string[]>([]),
+		required: v.array(v.string()).optional(() => []),
+		nullable: v.array(v.string()).optional(() => []),
 		properties: v.record(v.union(refVariantSchema, ipldTypeSchema, arraySchema, blobSchema, primitiveSchema)),
 	})
 	.chain(refineRequiredProperties);
@@ -189,7 +189,7 @@ export const xrpcParametersSchema = v
 	.object({
 		type: v.literal('params'),
 		description: v.string().optional(),
-		required: v.array(v.string()).default<string[]>([]),
+		required: v.array(v.string()).optional(() => []),
 		properties: v.record(v.union(primitiveSchema, primitiveArraySchema)),
 	})
 	.chain(refineRequiredProperties);


### PR DESCRIPTION
This pull request replaces the `.default(x)` pattern used in schemas with the pattern `.optional(() => x)`.

The new pattern was introduced in [@badrap/valita v0.3.11](https://github.com/badrap/valita/releases/tag/v0.3.11). It was marked non-experimental in the recent v0.3.12 release, but due to no changes in the functionality the dependency doesn't need to be updated in this pull request.

The rationale for the change was that `.default(x)` pattern has a pitfall when the default value is a mutable object. Because the same object gets used for each parsed missing/undefined value, mutating it may cause spooky action at a distance between seemingly unrelated parsed values. Therefore `.optional(() => x)` takes a function that's freshly evaluated for each parsed missing/undefined value, mitigating that specific pitfall with a slight cost of verbosity. To compensate that downside, the `<string[]>` annotations are not needed anymore 🙂

The`.default` method is marked deprecated and will be removed in a future version that has a version number that semver considers backwards incompatible.