### PR TITLE
test(core): add RPC tests

### DIFF
--- a/packages/core/client/lib/agent.test.ts
+++ b/packages/core/client/lib/agent.test.ts
@@ -234,6 +234,35 @@ describe('CredentialManager', () => {
 			expect(request.url).includes('/xrpc/com.atproto.server.getSession');
 		}
 	});
+
+	it('throws InvalidResponse when response cannot be parsed', async () => {
+		const fetch = vi.fn(globalThis.fetch);
+
+		const manager = new CredentialManager({ service: network.pds.url, fetch });
+		const rpc = new XRPC({ handler: manager });
+
+		await manager.login({ identifier: 'user1.test', password: 'password' });
+
+		await sleep(1_000);
+
+		fetch.mockResolvedValueOnce(
+			new Response('{invalid json}', {
+				status: 400,
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+
+		try {
+			await rpc.get('com.atproto.server.getSession', {});
+			expect.fail(`getSession call should not succeed`);
+		} catch (err) {
+			if (!(err instanceof XRPCError)) {
+				expect.fail(`No errors other than XRPC error should be thrown`);
+			}
+
+			expect(err.kind).toBe('InvalidResponse');
+		}
+	});
 });
 
 const createAccount = async (rpc: XRPC, handle: string) => {

--- a/packages/core/client/lib/rpc.test.ts
+++ b/packages/core/client/lib/rpc.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { TestNetwork } from '@atcute/internal-dev-env';
+
+import { clone, withProxy } from './rpc.js';
+import { simpleFetchHandler } from './fetch-handler.js';
+import { XRPC } from './rpc.js';
+
+let network: TestNetwork;
+
+beforeAll(async () => {
+	network = await TestNetwork.create({});
+});
+
+afterAll(async () => {
+	await network.close();
+});
+
+describe('XRPC', () => {
+	it('appends parameters to request', async () => {
+		const fetch = vi.fn(globalThis.fetch);
+		const handler = simpleFetchHandler({
+			service: network.pds.url,
+			fetch,
+		});
+		const rpc = new XRPC({ handler });
+
+		fetch.mockResolvedValueOnce(
+			new Response('{}', {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+
+		await rpc.get('com.atproto.admin.getAccountInfo', {
+			params: {
+				did: 'did:bleepbloop',
+			},
+		});
+
+		const lastURL = fetch.mock.lastCall![0] as URL;
+
+		expect(lastURL.search).to.equal('?did=did%3Ableepbloop');
+	});
+
+	it('stringifies non-string parameters', async () => {
+		const fetch = vi.fn(globalThis.fetch);
+		const handler = simpleFetchHandler({
+			service: network.pds.url,
+			fetch,
+		});
+		const rpc = new XRPC({ handler });
+
+		fetch.mockResolvedValueOnce(
+			new Response('{}', {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+
+		await rpc.get('com.atproto.admin.getInviteCodes', {
+			params: {
+				limit: 200,
+			},
+		});
+
+		const lastURL = fetch.mock.lastCall![0] as URL;
+
+		expect(lastURL.search).to.equal('?limit=200');
+	});
+
+	it('stringifies array parameters', async () => {
+		const fetch = vi.fn(globalThis.fetch);
+		const handler = simpleFetchHandler({
+			service: network.pds.url,
+			fetch,
+		});
+		const rpc = new XRPC({ handler });
+
+		fetch.mockResolvedValueOnce(
+			new Response('{}', {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+
+		await rpc.get('com.atproto.label.queryLabels', {
+			params: {
+				uriPatterns: ['a', 'b'],
+			},
+		});
+
+		const lastURL = fetch.mock.lastCall![0] as URL;
+
+		expect(lastURL.search).to.equal('?uriPatterns=a&uriPatterns=b');
+	});
+});
+
+describe('clone', () => {
+	it('clones an XRPC instance', async () => {
+		const fetch = vi.fn(globalThis.fetch);
+		const handler = simpleFetchHandler({
+			service: network.pds.url,
+			fetch,
+		});
+		const rpc = new XRPC({ handler });
+		const rpcClone = clone(rpc);
+
+		await rpc.get('com.atproto.server.describeServer', {});
+		await rpcClone.get('com.atproto.server.describeServer', {});
+
+		expect(rpc).not.toBe(rpcClone);
+		expect(fetch).toBeCalledTimes(2);
+	});
+});
+
+describe('withProxy', () => {
+	it('clones an XRPC instance and adds proxy', async () => {
+		const handler = simpleFetchHandler({
+			service: network.pds.url,
+			fetch,
+		});
+		const rpc = new XRPC({ handler });
+		const rpcClone = withProxy(rpc, {
+			service: 'did:dod',
+			type: 'atproto_labeler',
+		});
+
+		expect(rpc).not.toBe(rpcClone);
+		expect(rpcClone.proxy).toEqual({
+			service: 'did:dod',
+			type: 'atproto_labeler',
+		});
+	});
+});


### PR DESCRIPTION
Adds a few tests for some uncovered edge case stuff in RPC and `CredentialManager`.

I was digging around the repo and writing tests helps me get my head around it

let me know if you'd prefer them written a different way, happy to update