### PR TITLE
chore: add github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Build & Test
+
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node v${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+          node-version: ${{ matrix.node-version }}
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
+        run_install: false
+      - name: Install
+        run: pnpm i
+      - name: Build
+        run: pnpm run -r build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,6 @@ jobs:
         uses: pnpm/action-setup@v4
         run_install: false
       - name: Install
-        run: pnpm i
+        run: pnpm install
       - name: Build
-        run: pnpm run -r build
+        run: pnpm run --recursive build


### PR DESCRIPTION
Adds a simple build workflow to github CI.

This won't run the tests, only the build. until we add a root `test` script such that we can just `pnpm test` in `/`

Currently, we can't do `pnpm run -r test` since `bun` is missing. So we would need to decide if to install bun globally or use node, etc.