### PR TITLE
Remove isArray (invalid pure annotation)

### DIFF
--- a/packages/lexicons/lexicons/lib/validations/utils.ts
+++ b/packages/lexicons/lexicons/lib/validations/utils.ts
@@ -86,9 +86,7 @@ export const lazy = <T>(getter: () => T): { readonly value: T } => {
 	};
 };
 
-export const isArray = /*#__PURE__*/ Array.isArray;
-
 // #__NO_SIDE_EFFECTS__
 export const isObject = (input: unknown): input is Record<string, unknown> => {
-	return typeof input === 'object' && input !== null && !isArray(input);
+	return typeof input === 'object' && input !== null && !Array.isArray(input);
 };


### PR DESCRIPTION
I don't think the pure annotation is actually used here?
https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md doesn't list the way it's used here.

I also get an error from rollup when building my project:
```
node_modules/.pnpm/@atcute+lexicons@1.0.1/node_modules/@atcute/lexicons/dist/validations/utils.js (73:23): A comment

"/*#__PURE__*/"

in "node_modules/.pnpm/@atcute+lexicons@1.0.1/node_modules/@atcute/lexicons/dist/validations/utils.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
```