### PR TITLE
fix(lex-cli): use file protocol for config import

### DIFF
--- a/packages/lexicons/lex-cli/src/cli.ts
+++ b/packages/lexicons/lex-cli/src/cli.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import * as url from 'node:url';
 
 import { Builtins, Command, Option, Program } from '@externdefs/collider';
 import pc from 'picocolors';
@@ -32,8 +33,9 @@ program.register(
 
 			let config: LexiconConfig;
 			try {
-				const mod = (await import(path.resolve(configFilename))) as { default: LexiconConfig };
-				config = mod.default;
+				const configURL = url.pathToFileURL(configFilename);
+				const configMod = (await import(configURL.href)) as { default: LexiconConfig };
+				config = configMod.default;
 			} catch (err) {
 				console.error(pc.bold(pc.red(`failed to import config:`)));
 				console.error(err);


### PR DESCRIPTION
this PR makes the config import logic in `lex-cli` correctly format the path to a file URL.

not using a file URL here makes non-node engines attempt to use the Windows drive letter path as a URL protocol, which obviously fails. due to the existing duplicated `path.resolve` call inside of the `import` call, i can assume this was the original intention anyway, and that this is a typo.

i was unable to install the dependencies of the repo on my system due to issues with `node-gyp`, so i have not bumped the version or ran whichever tool creates the `.changesets` folder and manages the changelogs.