### PR TITLE
feat(lex-cli): add tsImports config option

### DIFF
--- a/packages/lexicons/lex-cli/src/cli.ts
+++ b/packages/lexicons/lex-cli/src/cli.ts
@@ -84,6 +84,7 @@ program.register(
 			const result = await generateLexiconApi({
 				documents: documents,
 				mappings: config.mappings ?? [],
+				ts: config.tsImports ?? false,
 				prettier: {},
 			});
 

--- a/packages/lexicons/lex-cli/src/codegen.ts
+++ b/packages/lexicons/lex-cli/src/codegen.ts
@@ -31,6 +31,7 @@ export interface ImportMapping {
 export interface LexiconApiOptions {
 	documents: LexiconDoc[];
 	mappings: ImportMapping[];
+	ts?: boolean;
 	prettier?: {
 		cwd?: string;
 	};
@@ -289,7 +290,7 @@ export const generateLexiconApi = async (opts: LexiconApiOptions): Promise<Lexic
 				const local = map.get(ns);
 
 				if (local) {
-					const target = `types/${ns.replaceAll('.', '/')}.js`;
+					const target = `types/${ns.replaceAll('.', '/')}.${opts.ts ? "ts" : "js"}`;
 
 					let relative = getRelativePath(dirname, target);
 					if (!relative.startsWith('.')) {
@@ -347,7 +348,7 @@ export const generateLexiconApi = async (opts: LexiconApiOptions): Promise<Lexic
 		let code = ``;
 
 		for (const doc of map.values()) {
-			code += `export * as ${toTitleCase(doc.id)} from ${lit(`./types/${doc.id.replaceAll('.', '/')}.js`)};\n`;
+			code += `export * as ${toTitleCase(doc.id)} from ${lit(`./types/${doc.id.replaceAll('.', '/')}.${opts.ts ? "ts" : "js"}`)};\n`;
 		}
 
 		files.push({

--- a/packages/lexicons/lex-cli/src/index.ts
+++ b/packages/lexicons/lex-cli/src/index.ts
@@ -4,6 +4,7 @@ export interface LexiconConfig {
 	outdir: string;
 	files: string[];
 	mappings?: ImportMapping[];
+	tsImports?: boolean;
 }
 
 export const defineLexiconConfig = (config: LexiconConfig): LexiconConfig => {


### PR DESCRIPTION
Primarily useful in environments with strict imports (e.g. Deno, a tsconfig.json with `rewriteRelativeImportExtensions` and `allowImportingTsExtensions` enabled).