### PR TITLE
ExpiresAt not set when refresh token present

### DIFF
--- a/packages/oauth/browser-client/lib/store/db.ts
+++ b/packages/oauth/browser-client/lib/store/db.ts
@@ -191,10 +191,6 @@ export const createOAuthDatabase = ({ name }: OAuthDatabaseOptions) => {
 		},
 
 		sessions: createStore('sessions', ({ token }) => {
-			if (token.refresh) {
-				return null;
-			}
-
 			return token.expires_at ?? null;
 		}),
 		states: createStore('states', (_item) => Date.now() + 10 * 60 * 1_000), // 10 minutes


### PR DESCRIPTION
When there is a refresh token in the token response expiresAt in the token store is not set preventing pdsls to remove the session 

Fixes https://tangled.org/@pdsls.dev/pdsls/issues/9