### PR TITLE
fix: validate DOH response when the comment is an array

### DIFF
--- a/packages/lexicons/lexicon-resolver/lib/authority/doh-json.ts
+++ b/packages/lexicons/lexicon-resolver/lib/authority/doh-json.ts
@@ -51,7 +51,7 @@ const result = v.object({
 	/** Authority */
 	Authority: v.array(authority).optional(),
 	/** Comment from the DNS server */
-	Comment: v.string().optional(),
+	Comment: v.union(v.string(), v.array(v.string())).optional(),
 });
 
 const SUBDOMAIN = '_lexicon';


### PR DESCRIPTION
Some DOH APIs like mozilla's return an array of strings as the comment instead of a string, causing it to throw during validation