### PR TITLE
Support defining nested objects in lexicons

### DIFF
--- a/packages/lexicons/lexicon-doc/lib/types.ts
+++ b/packages/lexicons/lexicon-doc/lib/types.ts
@@ -171,7 +171,7 @@ export type LexMeta = LexToken | LexRef | LexRefUnion | LexUnknown;
 /**
  * field definitions that can be declared inline in object properties and array items
  */
-export type LexDefinableField = LexConcrete | LexRef | LexRefUnion | LexUnknown | LexArray;
+export type LexDefinableField = LexConcrete | LexRef | LexRefUnion | LexUnknown | LexArray | LexObject;
 
 /**
  * all possible field definitions including those that must be referenced

--- a/packages/lexicons/lexicon-doc/lib/validations.ts
+++ b/packages/lexicons/lexicon-doc/lib/validations.ts
@@ -568,6 +568,10 @@ const buildLexDefinableField = (
 			cell = buildLexArray(ctx, path, spec);
 			break;
 		}
+		case 'object': {
+			cell = buildLexObject(ctx, path, spec);
+			break;
+		}
 
 		default: {
 			spec satisfies never;


### PR DESCRIPTION
At the moment, atcute rejects direct-nested objects in Lexicon type definitions. However, the [typescript reference implementation](https://github.com/bluesky-social/atproto/tree/main/packages/lexicon/src/validators), the [go reference implementation](https://github.com/bluesky-social/indigo/blob/main/atproto/lexicon/validation.go), and [honk](https://github.com/bigmoves/honk/tree/main/src/honk/validation) support it, and while [the Lexicon spec](https://atproto.com/specs/lexicon#object) defines objects as "A generic object schema which can be nested inside other definitions by reference", it *does not outright forbid* nesting inline objects like it specifies that `union`s must be objects.

Pending a proper clarification, this PR brings atcute in line with the other validator implementations and supports direct inlining of object definitions.