### PR TITLE
docs(oauth-browser-client): add name to Vite plugin

### DIFF
--- a/packages/oauth/browser-client/README.md
+++ b/packages/oauth/browser-client/README.md
@@ -197,6 +197,7 @@ export default defineConfig({
 	server: { host: SERVER_HOST, port: SERVER_PORT },
 	plugins: [
 		{
+			name: 'oauth-envs',
 			config(_conf, { command }) {
 				if (command === 'build') {
 					process.env.VITE_OAUTH_CLIENT_ID = metadata.client_id;


### PR DESCRIPTION
Without it you got a quite unhelpful TypeScript error that no overload matches this call.