### PR TITLE
chore(util-text): Further reduce install size

### DIFF
--- a/packages/misc/util-text/package.json
+++ b/packages/misc/util-text/package.json
@@ -8,7 +8,9 @@
 		"directory": "packages/misc/util-text"
 	},
 	"files": [
-		"dist/"
+		"dist/",
+		"!dist/*.bench.*",
+		"!dist/*.node.*"
 	],
 	"type": "module",
 	"sideEffects": false,

--- a/packages/misc/util-text/package.json
+++ b/packages/misc/util-text/package.json
@@ -8,11 +8,7 @@
 		"directory": "packages/misc/util-text"
 	},
 	"files": [
-		"dist/",
-		"lib/",
-		"src/",
-		"!lib/**/*.bench.ts",
-		"!lib/**/*.test.ts"
+		"dist/"
 	],
 	"type": "module",
 	"sideEffects": false,


### PR DESCRIPTION
This PR is a follow-up to 1b72c8c5bcb9721c5677901a6d34a7133dc3afb1 and #72 to further reduce the install size of `@atcute/util-text`

It drops the `src/` and `lib/` directories from the published package (the `src/` directory is 1.8 MB, so that one is a big saving).

It also drops the `index.node.*` and `index.bench.*` files from the published package.

I did this all via the `files` field in `package.json` to not interfere too much with the code. I guess in theory, the native source and Node entrypoint could be deleted entirely if they’re no longer being used, but I guessed maybe you wanted to keep them around for the future.

Thanks again for looking into this!