### PR TITLE
chore: add oauth node client npm metadata

### DIFF
--- a/packages/oauth/node-client/package.json
+++ b/packages/oauth/node-client/package.json
@@ -7,6 +7,10 @@
 		"url": "https://github.com/mary-ext/atcute",
 		"directory": "packages/oauth/node-client"
 	},
+	"homepage": "https://github.com/mary-ext/atcute/tree/trunk/packages/oauth/node-client#readme",
+	"bugs": {
+		"url": "https://github.com/mary-ext/atcute/issues"
+	},
 	"files": [
 		"dist/",
 		"lib/",


### PR DESCRIPTION
## Summary

Adds npm support metadata for the `@atcute/oauth-node-client` package.

## Why

The package already has repository metadata with its package directory. Adding `homepage` and `bugs.url` helps npm users and package tooling navigate to the package README and issue tracker.

## Testing

- Parsed `packages/oauth/node-client/package.json` with Node `JSON.parse`.
- Confirmed `homepage` and `bugs.url` are present.
- Ran `git diff --check`.
