### PR TITLE
fix(mst): hash a node's bytes against its CID before decoding it

### DIFF
--- a/packages/utilities/mst/lib/errors.ts
+++ b/packages/utilities/mst/lib/errors.ts
@@ -19,3 +19,15 @@ export class MissingBlockError extends Error {
 		this.def = def;
 	}
 }
+
+/** thrown when a block's bytes do not hash to the CID it was fetched under */
+export class BlockMismatchError extends Error {
+	cid: string;
+	actual: string;
+
+	constructor(cid: string, actual: string) {
+		super(`block does not match its cid; expected=${cid}; actual=${actual}`);
+		this.cid = cid;
+		this.actual = actual;
+	}
+}

--- a/packages/utilities/mst/lib/node-store.ts
+++ b/packages/utilities/mst/lib/node-store.ts
@@ -1,4 +1,6 @@
-import { MissingBlockError } from './errors.ts';
+import * as CID from '@atcute/cid';
+
+import { BlockMismatchError, MissingBlockError } from './errors.ts';
 import { MSTNode } from './node.ts';
 import type { BlockStore } from './stores.ts';
 import LRUCache from './utils/lru.ts';
@@ -20,6 +22,7 @@ export class NodeStore {
 	 * @param cid the CID of the node to retrieve, or null for empty node
 	 * @returns the MST node
 	 * @throws {MissingBlockError} if the node cannot be found in the store
+	 * @throws {BlockMismatchError} if the stored bytes do not hash to `cid`
 	 */
 	async get(cid: string | null): Promise<MSTNode> {
 		let node = this.cache.get(cid);
@@ -31,6 +34,13 @@ export class NodeStore {
 				const bytes = await this.store.get(cid);
 				if (bytes === null) {
 					throw new MissingBlockError(cid, 'MST node');
+				}
+
+				// the bytes come from a store we may not trust: hash them before decoding,
+				// so a block filed under the wrong CID fails as a mismatch, not as malformed
+				const actual = CID.toCidLink(await CID.create(0x71, bytes)).$link;
+				if (actual !== cid) {
+					throw new BlockMismatchError(cid, actual);
 				}
 
 				node = await MSTNode.deserialize(bytes);

--- a/packages/utilities/mst/lib/proof.test.ts
+++ b/packages/utilities/mst/lib/proof.test.ts
@@ -3,6 +3,8 @@ import { encodeUtf8 } from '@atcute/uint8array';
 
 import { describe, expect, it } from 'vitest';
 
+import { BlockMismatchError } from './errors.ts';
+import { MSTNode } from './node.ts';
 import { NodeStore } from './node-store.ts';
 import { NodeWrangler } from './node-wrangler.ts';
 import {
@@ -21,6 +23,33 @@ const createCid = async (data: string) => {
 };
 
 describe('Proof', () => {
+	it('should refuse a proof whose node bytes do not hash to their cid', async () => {
+		const store = new NodeStore(new MemoryBlockStore());
+		const wrangler = new NodeWrangler(store);
+
+		// build a tree with some records
+		let rootCid: string | null = null;
+		for (const key of ['a/1', 'b/2', 'c/3']) {
+			rootCid = await wrangler.putRecord(rootCid, key, await createCid(`value-${key}`));
+		}
+
+		// build inclusion proof for 'b/2'
+		const proof = await buildInclusionProof(store, rootCid!, 'b/2');
+
+		// create a new store with the proof blocks, but a different well-formed node under the root's CID
+		const forged = new MemoryBlockStore();
+		for (const cid of proof) {
+			const bytes = await store.store.get(cid);
+			if (bytes !== null) await forged.put(cid, bytes);
+		}
+		await forged.put(rootCid!, await MSTNode.empty().serialize());
+
+		// the swapped root must be refused as a mismatch
+		await expect(verifyInclusion(new NodeStore(forged), rootCid!, 'b/2')).rejects.toBeInstanceOf(
+			BlockMismatchError,
+		);
+	});
+
 	it('should build and verify inclusion proof', async () => {
 		const store = new NodeStore(new MemoryBlockStore());
 		const wrangler = new NodeWrangler(store);


### PR DESCRIPTION
NodeStore.get used whatever bytes the block store held for a CID without checking them. A CAR from an untrusted source can put different contents under a real CID, and verifyInclusion then treats that node as genuine.

This hashes each node before it is decoded and throws a new BlockMismatchError when the hash does not match the CID. 

Found while using @atcute/mst to check com.atproto.sync.getRecord proofs from a PDS. There's a scenario we found where a mirror or a relay sits between the PDS and the reader and a possibility that it serves a genuine signed commit with one of the tree nodes below it replaced; the signature still checks, so nothing else would catch it.


